### PR TITLE
refactor(sms): 优化 SMS 相关配置的获取逻辑

### DIFF
--- a/internal/logic/sms/sms_app_config.go
+++ b/internal/logic/sms/sms_app_config.go
@@ -43,7 +43,7 @@ func (s *sAppConfig) GetAppConfigByName(ctx context.Context, appName string) (*s
 		return nil, errors.New("{#error_sms_app_config_get_by_name_failed}" + s.dao.SmsAppConfig.Table())
 	}
 
-	res := kconv.Struct[*sms_model.SmsAppConfig](data, &sms_model.SmsAppConfig{})
+	res := kconv.Struct(data, &sms_model.SmsAppConfig{})
 
 	return res, nil
 }
@@ -62,7 +62,7 @@ func (s *sAppConfig) GetAppConfigById(ctx context.Context, id int64) (*sms_model
 		return nil, errors.New("{#error_sms_app_config_get_by_id_failed}" + s.dao.SmsAppConfig.Table())
 	}
 
-	res := kconv.Struct[*sms_model.SmsAppConfig](data, &sms_model.SmsAppConfig{})
+	res := kconv.Struct(data, &sms_model.SmsAppConfig{})
 
 	return res, nil
 }

--- a/internal/logic/sms/sms_service_provider_config.go
+++ b/internal/logic/sms/sms_service_provider_config.go
@@ -70,7 +70,7 @@ func (s *sServiceProviderConfig) GetProviderById(ctx context.Context, id int64) 
 		return nil, errors.New("{#error_sms_provider_get_by_id_failed}: " + err.Error() + s.dao.SmsServiceProviderConfig.Table())
 	}
 
-	res := kconv.Struct[*sms_model.SmsServiceProviderConfig](data, &sms_model.SmsServiceProviderConfig{})
+	res := kconv.Struct(data, &sms_model.SmsServiceProviderConfig{})
 
 	return res, nil
 }
@@ -88,7 +88,7 @@ func (s *sServiceProviderConfig) GetProviderByPriority(ctx context.Context, prio
 		return nil, errors.New("{#error_sms_provider_get_by_id_failed}: " + err.Error() + s.dao.SmsServiceProviderConfig.Table())
 	}
 
-	res := kconv.Struct[*sms_model.SmsServiceProviderConfig](data, &sms_model.SmsServiceProviderConfig{})
+	res := kconv.Struct(data, &sms_model.SmsServiceProviderConfig{})
 
 	return res, nil
 }
@@ -107,7 +107,7 @@ func (s *sServiceProviderConfig) QueryProviderByNo(ctx context.Context, no strin
 		return nil, errors.New("{#error_sms_provider_get_by_code_failed}: " + err.Error() + s.dao.SmsServiceProviderConfig.Table())
 	}
 
-	ret := kconv.Struct[*sms_model.ServiceProviderConfigListRes](res, &sms_model.ServiceProviderConfigListRes{})
+	ret := kconv.Struct(res, &sms_model.ServiceProviderConfigListRes{})
 
 	return ret, nil
 }


### PR DESCRIPTION
- 移除了 kconv.Struct 函数中的冗余泛型参数
- 统一了 kconv.Struct 的调用方式，提高代码可读性
- 涉及到的文件：
  - internal/logic/sms/sms_app_config.go
  - internal/logic/sms/sms_service_provider_config.go