### PR TITLE
refactor(internal): 重构权限初始化逻辑

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,4 +58,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace github.com/kysion/base-library => ../base-library
+replace github.com/kysion/base-library => ../base-library

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -10,13 +10,14 @@ import (
 // InitPermission 初始化权限树，需要先初始化完成 base_permission.Factory
 func InitPermission(module sms_interface.IModules, permission base_permission.IPermission) []base_permission.IPermission {
 	if permission == nil {
-		permission = base_permission.NewInIdentifier(module.GetConfig().Identifier.Sms, module.T(context.TODO(), "{#SmsName}"), "")
+		permission = base_permission.NewInIdentifier(module.GetConfig().Identifier.Sms, module.T(context.TODO(), "SmsName"), "")
 	}
 
 	result := []base_permission.IPermission{
-		// 资质
-		permission.SetId(5947986066667973).
-			SetName(module.T(context.TODO(), "{#SmsName}")).
+		// Sms
+		permission.
+			SetId(5947986066667973).
+			SetName(module.T(context.TODO(), "SmsName")).
 			SetIdentifier(module.GetConfig().Identifier.Sms).
 			SetType(1).
 			SetIsShow(1).


### PR DESCRIPTION
- 移除了 go.mod 中的注释
- 优化了 InitPermission 函数中的权限设置逻辑
- 替换了模块名称翻译的键值对引用